### PR TITLE
adding support for old hash permalinks. i think it works! :)

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -67,7 +67,7 @@
     
     headings: function headings(text) {
       // # or ...
-      var t = text || location.hash,
+      var t = text || location.hash.replace(/^#/,''),
       hdr = this.placeholder.find(':header'), h;
 
       // First thing first deal with headings and add proper data-wiki-hdr attribute
@@ -82,6 +82,10 @@
       h = hdr.filter('#' + t);
 
       if(!h.length) {
+        t = t.split(/#|★/);
+        
+        var navlinks = $('.wikiconvertor-pages a').filter('a[href^="/docs/'+ t[0] + '"]');
+        if ( navlinks.length ) location.href = navlinks[0].href + (t[1] ? '#' + t[1] : '');
         return;
       }
 


### PR DESCRIPTION
so that links like

http://html5boilerplate.com/docs/#FAQs★do-i-need-to-upgrade-my-sites-to-a-new-version

and 

http://html5boilerplate.com/docs/#Get-Started!

work.
