### PR TITLE
Let users override only options they care about.

### DIFF
--- a/bin/h5bp-cli.js
+++ b/bin/h5bp-cli.js
@@ -26,7 +26,7 @@ options = optimist.argv.config ?
   defaults;
 
 // get command line options, merge with defaults
-argv = optimist.default(options).argv;
+argv = optimist.default(defaults).default(options).argv;
 
 
 // basic help output when -h or --help used

--- a/conf/config.js
+++ b/conf/config.js
@@ -12,11 +12,16 @@ exports = module.exports = {
   // a single layout files with a {{ content }} placeholder.
   layout: "./index.html",
 
-  // How to replace the {{{ edit }}} placeholder. Must contain ":filename" somewhere.
-  edit: '<a class="edit-page" href="http://github.com/h5bp/html5-boilerplate/wiki/:filename/_edit">Edit this page</a>',
+  // Use a custom layout for MyCustom and TOC.
+  // Don't include the extension when specifying the file names.
+  customLayout: {'MyCustom': './custom.html',
+                 'TOC':  './toc.html'},
 
   // allowed extensions, all other files are ignored 
   ext: ['md', 'markdown', 'mkd'],
+
+  // How to replace the {{{ edit }}} placeholder. Must contain ":filename" somewhere.
+  edit: '<a class="edit-page" href="http://github.com/h5bp/html5-boilerplate/wiki/:filename/_edit">Edit this page</a>',
 
   // baseurl, only used with --server flag. ex: docs
   // also it helps to prefix links with some path

--- a/conf/config.js
+++ b/conf/config.js
@@ -12,6 +12,9 @@ exports = module.exports = {
   // a single layout files with a {{ content }} placeholder.
   layout: "./index.html",
 
+  // How to replace the {{{ edit }}} placeholder. Must contain ":filename" somewhere.
+  edit: '<a class="edit-page" href="http://github.com/h5bp/html5-boilerplate/wiki/:filename/_edit">Edit this page</a>',
+
   // allowed extensions, all other files are ignored 
   ext: ['md', 'markdown', 'mkd'],
 

--- a/conf/config.js
+++ b/conf/config.js
@@ -20,6 +20,9 @@ exports = module.exports = {
   // allowed extensions, all other files are ignored 
   ext: ['md', 'markdown', 'mkd'],
 
+  // Exclude some paths/directories. This is a list of JS regular expressions.
+  exclude: [],
+
   // How to replace the {{{ edit }}} placeholder. Must contain ":filename" somewhere.
   edit: '<a class="edit-page" href="http://github.com/h5bp/html5-boilerplate/wiki/:filename/_edit">Edit this page</a>',
 

--- a/lib/h5bp.js
+++ b/lib/h5bp.js
@@ -30,7 +30,7 @@ var Path = require('path'),
 connect = require('connect'),
 fs = require('fs'),
 findit = require('findit'),
-ghm = require('github-flavored-markdown'),
+marked = require('marked'),
 connect = require('connect'),
 Mustache = require('mustache'),
 prettify = require('../support/prettify'),
@@ -58,7 +58,7 @@ wikiAnchors = function wikiAnchors(text, config) {
   var bu = config.baseurl;
   text = text.replace(/\[\[([^|\]]+)\|([^\]]+)\]\]/g, function(wholeMatch, m1, m2) {
     var ext = /\/\//.test(m2),
-    path = ext ? m2 : Path.join(bu, m2.split(' ').join('-'));
+    path = ext ? m2 : Path.join(bu, m2.split(' ').join('-') + "/");
     return "["+m1+"](" + path + ")";
   });
 
@@ -100,7 +100,7 @@ codeHighlight = function codeHighlight(str) {
 
 // markdown parser to html and makes sure that code snippets are pretty enough
 toHtml = function toHtml(markdown, config) {
-  return codeHighlight( ghm.parse( wikiAnchors( escapeCodeBlock( markdown ), config) ) );
+  return codeHighlight( marked( wikiAnchors( escapeCodeBlock( markdown ), config) ) );
 },
 
 
@@ -175,6 +175,10 @@ exports = module.exports = function process(config) {
           return;
         }
 
+        if (config.exclude.some(function(regex) { return regex.test(file); })) {
+          return;
+        }
+
         // compute file's title: filename minus extension and -
         // compute href: filename/index.html
         // also takes care of files beginning by `.` like `.htaccess`
@@ -212,7 +216,7 @@ exports = module.exports = function process(config) {
           // generate edit this page link
           edit = config.edit.replace(':filename', file.filename);
 
-          output = Mustache.to_html(layoutTmpl, {
+          output = Mustache.render(layoutTmpl, {
             baseurl: config.baseurl,
             title: file.title,
             content: output,

--- a/lib/h5bp.js
+++ b/lib/h5bp.js
@@ -204,9 +204,8 @@ exports = module.exports = function process(config) {
           dest = Path.join(destPath, file.title === 'Home' ? '' : file.filename),
           edit;
 
-          // generate edit this page link, todo: set it part of the template
-          edit = '<a class="edit-page" href="//github.com/h5bp/html5-boilerplate/wiki/:filename/_edit">Edit this page</a>'
-            .replace(':filename', file.filename);
+          // generate edit this page link
+          edit = config.edit.replace(':filename', file.filename);
 
           output = Mustache.to_html(layoutTmpl, {
             baseurl: config.baseurl,

--- a/lib/h5bp.js
+++ b/lib/h5bp.js
@@ -130,13 +130,18 @@ copyAssets = function copyAssets(config) {
 // utilty helper to determine which layout to use. It first tries to
 // get a layout template from where the excutable was used, it then fallbacks
 // to the default layout.
-computeLayout = function(config) {
-  var layout;
+computeLayout = function(config, file) {
+  var layout, configLayout = config.layout;
+
+  if (file.filename in config.customLayout) {
+    configLayout = config.customLayout[file.filename];
+    console.log('Using custom layout for', file.filename);
+  }
 
   try {
-    layout = fs.readFileSync(Path.join(basePath, config.layout), 'utf8').toString();
+    layout = fs.readFileSync(Path.join(basePath, configLayout), 'utf8').toString();
   } catch (e) {
-    console.log('Unable to find ', Path.join(basePath, config.layout), '. Fallback to ', Path.join(__dirname, '..', 'index.html'));
+    console.log('Unable to find ', Path.join(basePath, configLayout), '. Fallback to ', Path.join(__dirname, '..', 'index.html'));
     layout = fs.readFileSync(Path.join(__dirname, '..', 'index.html'), 'utf8').toString();
   }
 
@@ -151,7 +156,6 @@ exports = module.exports = function process(config) {
 
   var files = [],
   fileReg = new RegExp('\\.' + config.ext.join('$|\\.') + '$'),
-  layoutTmpl = computeLayout(config),
   destPath = Path.join(basePath, config.dest),
   srcPath = Path.join(basePath, config.src),
   print = function print() {
@@ -202,6 +206,7 @@ exports = module.exports = function process(config) {
         files.forEach(function(file) {
           var output = toHtml(fs.readFileSync(file.path, 'utf8'), config),
           dest = Path.join(destPath, file.title === 'Home' ? '' : file.filename),
+          layoutTmpl = computeLayout(config, file),
           edit;
 
           // generate edit this page link

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "h5bp-docs",
   "description": "h5bp documentation generator",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "./lib/h5bp.js",
   "bin": "./bin/h5bp-cli.js",
   "engines": {
@@ -9,9 +9,9 @@
   },
   "dependencies": {
     "findit": "0.1.0",
-    "github-flavored-markdown": "1.0.0",
+    "marked": "0.3.2",
     "connect": "1.5.1",
-    "mustache": "0.3.1-dev",
+    "mustache": "0.8.1",
     "optimist": "0.2.5",
     "seq": "0.3.5",
     "wordwrap": "0.0.2"

--- a/readme.md
+++ b/readme.md
@@ -60,8 +60,16 @@ The following is a list of the currently supported configuration options. These 
   // a single layout files with {{{ content }}} placeholder
   layout: "./index.html",
   
+  // Use a custom layout for MyCustom and TOC.
+  // Don't include the extension when specifying the file names.
+  customLayout: {'MyCustom': './custom.html',
+                 'TOC':  './toc.html'},
+  
   // allowed extensions, all other files are ignored 
   ext: ['md', 'markdown', 'mkd'],
+  
+  // How to replace the {{{ edit }}} placeholder. Must contain ":filename" somewhere.
+  edit: '<a class="edit-page" href="http://github.com/h5bp/html5-boilerplate/wiki/:filename/_edit">Edit this page</a>',
   
   // baseurl, only used with --server flag. ex: docs
   baseurl: '',

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,9 @@ The following is a list of the currently supported configuration options. These 
   // allowed extensions, all other files are ignored 
   ext: ['md', 'markdown', 'mkd'],
   
+  // Exclude some paths/directories. This is a list of JS regular expressions.
+  exclude: [/hidden\.dir/, /.*\.hide\.md/],
+  
   // How to replace the {{{ edit }}} placeholder. Must contain ":filename" somewhere.
   edit: '<a class="edit-page" href="http://github.com/h5bp/html5-boilerplate/wiki/:filename/_edit">Edit this page</a>',
   


### PR DESCRIPTION
Without this change, the user-provided config file has to contain _all_ settings, not just the ones the user cares about. With this change, we start with the defaults, and override them with the user-provided config file contents (if any).
